### PR TITLE
Fix BUILD_GROUP with id -g -n for standalone builds

### DIFF
--- a/scripts/compile_kernel.sh
+++ b/scripts/compile_kernel.sh
@@ -25,8 +25,8 @@ if [ -d /vagrant ]; then
 else
   # running in drone build
   SRC_DIR=`pwd`
-  BUILD_USER=`whoami`
-  BUILD_GROUP=`whoami`
+  BUILD_USER=`id -u -n`
+  BUILD_GROUP=`id -g -n`
 fi
 
 LINUX_KERNEL_CONFIGS=$SRC_DIR/kernel_configs


### PR DESCRIPTION
This works in a standalone build environment without Vagrant.
Our CI also seems to be happy with it.

Closes #8