### PR TITLE
Fix kernel version in deb packages

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,10 +1,22 @@
 #!/bin/bash -e
 
-echo "$CIRCLE_TAG"
+echo "Circle Tag: $CIRCLE_TAG"
 
 if [ "$CIRCLE_TAG" != "" ]; then
   gem install package_cloud
-  package_cloud push Hypriot/rpi/debian/stretch output/*/raspberrypi-kernel*.deb
+  package_cloud push Hypriot/rpi/debian/stretch output/*/raspberrypi-kernel*.deb output/*/linux-libc-dev*.deb
+
+  curl -sSL https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip -o ghr.zip
+  unzip ghr.zip
+  mkdir ghroutput
+  cp output/*/raspberrypi-kernel*.deb ghroutput/
+  cp output/*/linux-libc-dev*.deb ghroutput/
+
+  if [[ $CIRCLE_TAG = *"rc"* ]]; then
+    pre=-prerelease
+  fi
+  ./ghr $pre -u hypriot "$CIRCLE_TAG" ghroutput/
+
 else
   echo "No release tag detected. Skip deployment."
 fi


### PR DESCRIPTION
Generate raspberrypi-kernel-headers package with correct kernel headers from 4.9.80 build.
Fix deb control files (postinst, ...) to use current kernel version instead of fixed 4.9.59 from RPi-Distro/firmware/debian script.

Fixes #41 