### PR TITLE
Build With Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   build:
-    machine: true
+    docker:
+      - image: buildpack-deps:trusty-scm
     steps:
       - checkout
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,18 +30,23 @@ def get_cpu_setting(host)
 end
 
 Vagrant.configure(2) do |config|
-  override.vm.box = "ubuntu/trusty64"
   config.vm.synced_folder ".", "/vagrant"
   config.vm.define "docker-raspbian" do |config|
     config.vm.hostname = "docker-raspbian"
     config.ssh.forward_agent = true
     config.vm.provision "shell", path: "scripts/provision.sh", privileged: false
-    config.vm.provider "virtualbox" do |vb|
+    config.vm.provider "virtualbox" do |vb, override|
+       override.vm.box = "ubuntu/trusty64"
        # find out on which host os we are running
        host = RbConfig::CONFIG['host_os']
        vb.customize ["modifyvm", :id, "--ioapic", "on"]
        vb.memory = get_memory_setting(host)
        vb.cpus = get_cpu_setting(host)
+    end
+    config.vm.provider "docker" do |docker|
+      docker.image = "tknerr/baseimage-ubuntu:14.04"
+      docker.has_ssh = true
+      docker.remains_running = false
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,7 @@ def get_cpu_setting(host)
 end
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "boxcutter/ubuntu1404"
+  override.vm.box = "ubuntu/trusty64"
   config.vm.synced_folder ".", "/vagrant"
   config.vm.define "docker-raspbian" do |config|
     config.vm.hostname = "docker-raspbian"


### PR DESCRIPTION
Added the ability to build using Docker, both in Vagrant and in Circle CI. Within Circle CI, this decreases build time from ~90 minutes to ~40 minutes . This could be decreased further by optimizing the way we pull code from git. (I have this available if you want it.)
Note that I also switched the Vagrant virtual box configuration to use Canonical's Ubuntu image instead of Boxcutter's image. Boxcutter is still around, but renamed to box-cutter. But unfortunately it returns a 404 when trying to pull it's image.