### PR TITLE
Avoid unnecessary deleting and re-checking out of the kernel source

### DIFF
--- a/scripts/compile_kernel.sh
+++ b/scripts/compile_kernel.sh
@@ -83,9 +83,6 @@ function clone_or_update_repo_for () {
   local repo_path=$2
   local repo_commit=$3
 
-  if [ ! -z "${repo_commit}" ]; then
-    rm -rf $repo_path
-  fi
   if [ -d ${repo_path}/.git ]; then
     pushd $repo_path
     git reset --hard HEAD


### PR DESCRIPTION
Avoid the long and resource intensive task of deleting the kernel source and then checking out that same kernel source

Closes #52