### PR TITLE
fix: avoid a fatal error when trying to compile the kernel #58

### DIFF
--- a/scripts/compile_kernel.sh
+++ b/scripts/compile_kernel.sh
@@ -227,7 +227,7 @@ function create_kernel_deb_packages () {
 
   (cd $NEW_KERNEL/debian ; ./gen_bootloader_postinst_preinst.sh)
 
-  dch -v ${NEW_VERSION} --package raspberrypi-firmware 'add Hypriot custom kernel'
+  dch -b -v ${NEW_VERSION} --package raspberrypi-firmware 'add Hypriot custom kernel'
   debuild --no-lintian -ePATH=${PATH}:$ARM_TOOLS/$X64_CROSS_COMPILE_CHAIN/bin -b -aarmhf -us -uc
   cp ../*.deb $BUILD_RESULTS
   if [[ ! -z $CIRCLE_ARTIFACTS ]]; then


### PR DESCRIPTION
Closes #58 